### PR TITLE
Resolve Travis CI new distro issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false # use container-based infrastructure
 
+dist: trusty
+
 language: java
 jdk:
   - oraclejdk8 # test against version 1.8


### PR DESCRIPTION
Explicitly set dist: trusty in .travis.yml file to route builds back to the Trusty distribution.