### PR TITLE
DEV-1174 Fix directory traversal in services-in-one

### DIFF
--- a/service-transmission/src/main/java/sg/ncl/service/transmission/logic/UploadServiceImpl.java
+++ b/service-transmission/src/main/java/sg/ncl/service/transmission/logic/UploadServiceImpl.java
@@ -3,7 +3,9 @@ package sg.ncl.service.transmission.logic;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
 import sg.ncl.common.exception.base.BadRequestException;
+import sg.ncl.common.exception.base.UnauthorizedException;
 import sg.ncl.service.transmission.DirectoryProperties;
 import sg.ncl.service.transmission.data.ResumableEntity;
 import sg.ncl.service.transmission.data.ResumableStorage;
@@ -65,6 +67,23 @@ public class UploadServiceImpl implements UploadService {
 
     @Override
     public UploadStatus addChunk(ResumableInfo resumableInfo, int resumableChunkNumber, String subDirKey, String preDir) {
+
+        try{
+            String decodeFileName = UriUtils.decode(resumableInfo.getResumableFilename(), "UTF-8");
+            if (HttpUtils.isFilePathUnsafe(properties, decodeFileName)) {
+                throw new UnauthorizedException("Unauthorized path");
+            }
+
+            String decodeIdentifier = UriUtils.decode(resumableInfo.getResumableIdentifier(), "UTF-8");
+            if (HttpUtils.isFilePathUnsafe(properties, decodeIdentifier)) {
+                throw new UnauthorizedException("Unauthorized identifier");
+            }
+
+        }catch (IOException e) {
+            log.error("Unable to decode addChunk filename: {}", e);
+            throw new BadRequestException();
+        }
+
         Path path = HttpUtils.getPath(properties, subDirKey, preDir);
         createDirectoryOrCheckFileExists(path, resumableInfo);
 

--- a/service-transmission/src/main/java/sg/ncl/service/transmission/util/HttpUtils.java
+++ b/service-transmission/src/main/java/sg/ncl/service/transmission/util/HttpUtils.java
@@ -74,6 +74,25 @@ public class HttpUtils {
         return Paths.get(path.getRoot().toString(), baseDir);
     }
 
+    public static boolean isFilePathUnsafe(DirectoryProperties properties, String filename){
+        boolean unsafePath = false;
+        String baseDir = properties.getBaseDir();
+
+        if(filename.contains("../") || filename.contains("./") || filename.contains("..")){
+            unsafePath = true;
+        }
+
+        Path baseDirPath = Paths.get(baseDir);
+        Path userPath = Paths.get(filename);
+        final Path resolvedPath = baseDirPath.resolve(userPath).normalize();
+        if (!resolvedPath.startsWith(baseDirPath)) {
+            unsafePath = true;
+        }
+
+        return unsafePath;
+    }
+
+
     public static void removeDirectory(File dir) {
         boolean deleted;
         if (dir.isDirectory()) {


### PR DESCRIPTION
Fixes:
1. Sanitize input against directory traversal commands
2. Ensure that resolved path is always within base directory /mnt/resources